### PR TITLE
Add option to download report with icon changes

### DIFF
--- a/app/controllers/section_processes_controller.rb
+++ b/app/controllers/section_processes_controller.rb
@@ -38,6 +38,11 @@ class SectionProcessesController < ApplicationController
     respond_success('Successfully sent the report to your email', section_path(@section))
   end
 
+  def download_report
+    pdf = ::Reports::Section.new(@section).to_pdf
+    send_data(pdf, filename: "section_report_for_#{@section.name}.pdf", type: 'application/pdf')
+  end
+
   def destroy_section
     @section.destroy
     respond_success('Successfully deleted the section', dashboard_path)

--- a/app/controllers/student_processes_controller.rb
+++ b/app/controllers/student_processes_controller.rb
@@ -63,6 +63,11 @@ class StudentProcessesController < ApplicationController
     respond_success('Successfully sent the report to the student\'s email', student_path(@section, @student))
   end
 
+  def download_report
+    pdf = ::Reports::Student.new(@student).to_pdf
+    send_data(pdf, filename: "student_report_for_#{@studen.last_name}_#{@studen.first_name}.pdf", type: 'application/pdf')
+  end
+
   private
 
   def set_section

--- a/app/views/sections/show.html.erb
+++ b/app/views/sections/show.html.erb
@@ -7,19 +7,30 @@
     <h5 class="m-0 text-muted mb-2">NO. OF STUDENTS : <span class="ml-3 px-3 text-light font-weight-bold bg-primary rounded"><%= @section.students.count %></span></h5>
   </div>
   <div class="card-body">
-    <div class="d-sm-flex mb-5">
-      <a class="btn btn-warning btn-circle text-center mr-2" href="#" data-toggle="modal" data-target="#updateSectionModal_<%= @section.id %>">
-        <i class="fas fa-pencil-alt"></i>
-      </a>
-      <a class="btn btn-danger btn-circle text-center" href="#" data-toggle="modal" data-target="#deleteSectionModal_<%= @section.id %>">
-        <i class="fas fa-trash"></i>
-      </a>
-      <%= link_to section_report_path(@section), method: 'post', class: 'btn btn-primary btn-icon-split ml-auto' do %>
-        <span class="icon text-white-50">
-          <i class="fas fa-download"></i>
-        </span>
-        <span class="text">Generate Report</span>
-      <% end %>
+    <div class="d-sm-flex justify-content-between mb-5">
+      <div>
+        <a class="btn btn-warning btn-circle text-center mr-2" href="#" data-toggle="modal" data-target="#updateSectionModal_<%= @section.id %>">
+          <i class="fas fa-pencil-alt"></i>
+        </a>
+        <a class="btn btn-danger btn-circle text-center" href="#" data-toggle="modal" data-target="#deleteSectionModal_<%= @section.id %>">
+          <i class="fas fa-trash"></i>
+        </a>
+      </div>
+      <div>
+        <%= link_to section_report_path(@section), method: 'post', class: 'btn btn-primary btn-icon-split ml-auto' do %>
+          <span class="icon text-white-50">
+            <i class="fas fa-paper-plane"></i>
+          </span>
+          <span class="text">Send Report to Email</span>
+        <% end %>
+
+        <%= link_to section_report_dowload_path(@section), class: 'btn btn-primary btn-icon-split ml-auto' do %>
+          <span class="icon text-white-50">
+            <i class="fas fa-download"></i>
+          </span>
+          <span class="text">Download Report</span>
+        <% end %>
+      </div>
     </div>
     <div class="row d-flex justify-content-around">
       <div class="col-xl-6 col-md-6 mb-4">

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -24,11 +24,18 @@
   </div>
   <div class="card-body">
     <div class="d-sm-flex align-items-center justify-content-end mb-4">
-      <%= link_to student_report_path(id: @section.id, student_id: @student.id), method: 'post', class: 'btn btn-primary btn-icon-split ml-auto' do %>
+      <%= link_to student_report_path(id: @section.id, student_id: @student.id), method: 'post', class: 'btn btn-primary btn-icon-split ml-2' do %>
+        <span class="icon text-white-50">
+          <i class="fas fa-paper-plane"></i>
+        </span>
+        <span class="text">Send Report to Student</span>
+      <% end %>
+
+      <%= link_to student_report_dowload_path(id: @section.id, student_id: @student.id), class: 'btn btn-primary btn-icon-split ml-2' do %>
         <span class="icon text-white-50">
           <i class="fas fa-download"></i>
         </span>
-        <span class="text">Generate Report</span>
+        <span class="text">Download Report</span>
       <% end %>
     </div>
     <div class="row d-flex justify-content-around">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
   # SECTION PROCESSES
   post '/sections/:id/report', to: 'section_processes#section_report_to_email', as: 'section_report'
+  get '/sections/:id/report', to: 'section_processes#download_report', as: 'section_report_dowload'
   put '/sections/:id/update', to: 'section_processes#update_section', as: 'section_update'
   put '/sections/:id/attendances/:attendance_id/update', to: 'section_processes#update_section_attendance', as: 'section_attendance_update'
   put '/sections/:id/seatworks/:seatwork_id/update', to: 'section_processes#update_section_seatwork', as: 'section_seatwork_update'
@@ -41,6 +42,7 @@ Rails.application.routes.draw do
 
   # STUDENT PROCESSES
   post '/sections/:id/students/:student_id/report', to: 'student_processes#student_report_to_email', as: 'student_report'
+  get '/sections/:id/students/:student_id/report', to: 'student_processes#download_report', as: 'student_report_dowload'
   put '/sections/:id/students/:student_id/update', to: 'student_processes#update_student', as: 'student_update'
   put '/sections/:id/students/:student_id/seatworks/:seatwork_id', to: 'student_processes#update_student_seatwork', as: 'student_update_seatwork'
   put '/sections/:id/students/:student_id/homeworks/:homework_id', to: 'student_processes#update_student_homework', as: 'student_update_homework'


### PR DESCRIPTION
fix for issue #24 

- [x] Change the icon for 'Download Report' into a paperplane and relabed it to 'Send to Email'
- [x] Add an option to 'Download Report' directly instead of sending it to email of a student/teacher

``` section buttons ```
![screen](https://user-images.githubusercontent.com/61614867/114362051-79318980-9ba9-11eb-91f5-bb1812eee1a4.jpg)

``` student buttons ```
![screen2](https://user-images.githubusercontent.com/61614867/114362090-86e70f00-9ba9-11eb-8cd1-b2eaab75d618.jpg)
